### PR TITLE
Update ch8-08.md

### DIFF
--- a/ch8/ch8-08.md
+++ b/ch8/ch8-08.md
@@ -131,7 +131,7 @@ $ ./du2 -v $HOME /usr /bin /etc
 213201 files  62.7 GB
 ```
 
-然而这个程序还是会花上很长时间才会结束。无法对walkDir做并行化处理没什么别的原因，无非是因为磁盘系统并行限制。下面这个第三个版本的du，会对每一个walkDir的调用创建一个新的goroutine。它使用sync.WaitGroup (§8.5)来对仍旧活跃的walkDir调用进行计数，另一个goroutine会在计数器减为零的时候将fileSizes这个channel关闭。
+然而这个程序还是会花上很长时间才会结束。完全可以并发调用walkDir，从而发挥磁盘系统的并行性能。下面这个第三个版本的du，会对每一个walkDir的调用创建一个新的goroutine。它使用sync.WaitGroup (§8.5)来对仍旧活跃的walkDir调用进行计数，另一个goroutine会在计数器减为零的时候将fileSizes这个channel关闭。
 
 <u><i>gopl.io/ch8/du3</i></u>
 ```go


### PR DESCRIPTION
原文如下：
> There’s no reason why all the calls to walkDir can’t be done concurrently, thereby exploiting parallelism in the disk system.

如果直译应该是：“没有理由不可以并发调用walkDir，从而发挥磁盘系统的并行性能。”

双重否定显得有点儿啰嗦，建议直接用加强肯定句：“完全可以并发调用walkDir，从而发挥磁盘系统的并行性能”

