### PR TITLE
修改一处笔误, '系列' 修改为 '序列'

### DIFF
--- a/ch4/ch4-02.md
+++ b/ch4/ch4-02.md
@@ -44,7 +44,7 @@ endlessSummer := summer[:5] // extend a slice (within capacity)
 fmt.Println(endlessSummer)  // "[June July August September October]"
 ```
 
-另外，字符串的切片操作和[]byte字节类型切片的切片操作是类似的。都写作x[m:n]，并且都是返回一个原始字节系列的子序列，底层都是共享之前的底层数组，因此这种操作都是常量时间复杂度。x[m:n]切片操作对于字符串则生成一个新字符串，如果x是[]byte的话则生成一个新的[]byte。
+另外，字符串的切片操作和[]byte字节类型切片的切片操作是类似的。都写作x[m:n]，并且都是返回一个原始字节序列的子序列，底层都是共享之前的底层数组，因此这种操作都是常量时间复杂度。x[m:n]切片操作对于字符串则生成一个新字符串，如果x是[]byte的话则生成一个新的[]byte。
 
 因为slice值包含指向第一个slice元素的指针，因此向函数传递slice将允许在函数内部修改底层数组的元素。换句话说，复制一个slice只是对底层的数组创建了一个新的slice别名（§2.3.2）。下面的reverse函数在原内存空间将[]int类型的slice反转，而且它可以用于任意长度的slice。
 


### PR DESCRIPTION
第四章第二节，有一处笔误将。英文原文 “and both return a subsequence of the original bytes,”，翻译应该为字节序列。