### PR TITLE
Update ch5-06.md

### DIFF
--- a/ch5/ch5-06.md
+++ b/ch5/ch5-06.md
@@ -101,7 +101,7 @@ visitAll := func(items []string) {
 }
 ```
 
-在topsort中，首先对prereqs中的key排序，再调用visitAll。因为prereqs映射的是切片而不是更复杂的map，所以数据的遍历次序是固定的，这意味着你每次运行topsort得到的输出都是一样的。	topsort的输出结果如下:
+在toposort程序的输出如下所示，它的输出顺序是大多人想看到的固定顺序输出，但是这需要我们多花点心思才能做到。哈希表prepreqs的value是遍历顺序固定的切片，而不再试遍历顺序随机的map，所以我们对prereqs的key值进行排序，保证每次运行toposort程序，都以相同的遍历顺序遍历prereqs。
 
 ```
 1: intro to programming


### PR DESCRIPTION
之前的翻译有些许晦涩，没有表达出主要意思。查阅原文后重新翻译。
请谨慎合并。

英文原文如下：
The out put of the toposort prog ram is shown below. It is deter minist ic, an often-desirable
prop erty that doesn’t always come for fre e. Here, the values of the prereqs map are slices, not
more maps, so their iterat ion order is deter minist ic, and we sor ted the keys of prereqs before
making the initial cal ls to visitAll.

主要表达意思是：因为 prereqs （map）的遍历顺序是随机的，所以需要它的key值做排序，保证每次运行程序的输出结果是固定的（如大多数人预想的那样）。而prereqs的值是slice，是固定顺序的，所以不要进行排序。

参考资料：https://blog.golang.org/maps 的 Iteration order部分
