### PR TITLE
Update ch2-06.md

### DIFF
--- a/ch2/ch2-06.md
+++ b/ch2/ch2-06.md
@@ -186,6 +186,8 @@ var pc [256]byte = func() (pc [256]byte) {
 
 ```Go
 for i, _ := range pc {
+	pc[i] = pc[i/2] + byte(i&1)
+}
 ```
 
 我们在下一节和10.5节还将看到其它使用init函数的地方。


### PR DESCRIPTION
原文为 `for i, _ := range pc { `

是否应该补充为下面这样看的更好一点，虽然差别不大

```
for i, _ := range pc {
	pc[i] = pc[i/2] + byte(i&1)
}

```
提示：解决了什么问题，也可以讲下理由。
