### PR TITLE
Update ch4-03.md

### DIFF
--- a/ch4/ch4-03.md
+++ b/ch4/ch4-03.md
@@ -264,7 +264,7 @@ len count
 4   0
 ```
 
-Map的value类型也可以是一个聚合类型，比如是一个map或slice。在下面的代码中，图graph的key类型是一个字符串，value类型map[string]bool代表一个字符串集合。从概念上讲，graph将一个字符串类型的key映射到一组相关的字符串集合，它们指向新的graph的key。
+Map的value类型也可以是一个聚合类型，比如是一个map或slice。在下面的代码中，graph 这个 map 的key类型是一个字符串，value类型map[string]bool代表一个字符串集合。从概念上讲，graph将一个字符串类型的key映射到一组相关的字符串集合，它们指向新的graph的key。
 
 <u><i>gopl.io/ch4/graph</i></u>
 ```Go


### PR DESCRIPTION
原文为：

`在下面的代码中，图graph的key类型是一个字符串`

这个是不是机翻的时候失误导致了，改成下面这样会不会好点：

`graph 这个 map 的key类型是一个字符串`

提示：解决了什么问题，也可以讲下理由。
