### PR TITLE
fix: correct typo "而不再试" → "而不再是"

### DIFF
--- a/ch5/ch5-06.md
+++ b/ch5/ch5-06.md
@@ -101,7 +101,7 @@ visitAll := func(items []string) {
 }
 ```
 
-在toposort程序的输出如下所示，它的输出顺序是大多人想看到的固定顺序输出，但是这需要我们多花点心思才能做到。哈希表prepreqs的value是遍历顺序固定的切片，而不再试遍历顺序随机的map，所以我们对prereqs的key值进行排序，保证每次运行toposort程序，都以相同的遍历顺序遍历prereqs。
+在toposort程序的输出如下所示，它的输出顺序是大多人想看到的固定顺序输出，但是这需要我们多花点心思才能做到。哈希表prepreqs的value是遍历顺序固定的切片，而不再是遍历顺序随机的map，所以我们对prereqs的key值进行排序，保证每次运行toposort程序，都以相同的遍历顺序遍历prereqs。
 
 ```
 1: intro to programming
@@ -302,3 +302,4 @@ for i := 0; i < len(dirs); i++ {
 ```
 
 如果你使用go语句（第八章）或者defer语句（5.8节）会经常遇到此类问题。这不是go或defer本身导致的，而是因为它们都会等待循环结束后，再执行函数值。
+


### PR DESCRIPTION
@chai2010 

This pull request fixes a typo in the documentation.  
The original text mistakenly used "而不再试" (meaning "no longer try"),  
which should be "而不再是" (meaning "no longer is").  

This correction makes the sentence semantically accurate and avoids confusion for readers.
